### PR TITLE
fix: mark badge component as client component

### DIFF
--- a/src/components/base/badge.tsx
+++ b/src/components/base/badge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as Headless from "@headlessui/react";
 import React, { forwardRef } from "react";
 

--- a/src/components/base/link.tsx
+++ b/src/components/base/link.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DataInteractive } from "@headlessui/react";
 import NextLink from "next/link";
 import { forwardRef } from "react";


### PR DESCRIPTION
## Summary
- add a "use client" directive to the base Link wrapper so HeadlessUI dependencies compile on the client
- mark the base Badge wrapper as a client component to allow HeadlessUI buttons to render client-side

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec89bc2258832e8be4aeeb8d79470d