### PR TITLE
Limit dialog close actions to mobile

### DIFF
--- a/src/components/base/dialog.tsx
+++ b/src/components/base/dialog.tsx
@@ -1,0 +1,98 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import * as Headless from "@headlessui/react";
+import { clsx } from "clsx";
+
+import { Text } from "./text";
+
+const sizes = {
+  xs: "sm:max-w-xs",
+  sm: "sm:max-w-sm",
+  md: "sm:max-w-md",
+  lg: "sm:max-w-lg",
+  xl: "sm:max-w-xl",
+  "2xl": "sm:max-w-2xl",
+  "3xl": "sm:max-w-3xl",
+  "4xl": "sm:max-w-4xl",
+  "5xl": "sm:max-w-5xl",
+};
+
+export function Dialog({
+  size = "lg",
+  className,
+  children,
+  ...props
+}: {
+  size?: keyof typeof sizes;
+  className?: string;
+  children: ReactNode;
+} & Omit<Headless.DialogProps, "as" | "className">) {
+  return (
+    <Headless.Dialog {...props}>
+      <Headless.DialogBackdrop
+        transition
+        className="fixed inset-0 flex w-screen justify-center overflow-y-auto bg-zinc-950/25 px-2 py-2 transition duration-100 focus:outline-0 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:px-6 sm:py-8 lg:px-8 lg:py-16 dark:bg-zinc-950/50"
+      />
+
+      <div className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0">
+        <div className="grid min-h-full grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr] sm:p-4">
+          <Headless.DialogPanel
+            transition
+            className={clsx(
+              className,
+              sizes[size],
+              "row-start-2 w-full min-w-0 rounded-t-3xl bg-white p-(--gutter) shadow-lg ring-1 ring-zinc-950/10 [--gutter:--spacing(8)] sm:mb-auto sm:rounded-2xl dark:bg-zinc-900 dark:ring-white/10 forced-colors:outline",
+              "transition duration-100 will-change-transform data-closed:translate-y-12 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:data-enter:scale-95"
+            )}
+          >
+            {children}
+          </Headless.DialogPanel>
+        </div>
+      </div>
+    </Headless.Dialog>
+  );
+}
+
+export function DialogTitle({
+  className,
+  ...props
+}: { className?: string } & Omit<Headless.DialogTitleProps, "as" | "className">) {
+  return (
+    <Headless.DialogTitle
+      {...props}
+      className={clsx(
+        className,
+        "text-lg/6 font-semibold text-balance text-zinc-950 sm:text-base/6 dark:text-white"
+      )}
+    />
+  );
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: { className?: string } & Omit<Headless.DescriptionProps<typeof Text>, "as" | "className">) {
+  return (
+    <Headless.Description
+      as={Text}
+      {...props}
+      className={clsx(className, "mt-2 text-pretty")}
+    />
+  );
+}
+
+export function DialogBody({ className, ...props }: ComponentPropsWithoutRef<"div">) {
+  return <div {...props} className={clsx(className, "mt-6")} />;
+}
+
+export function DialogActions({ className, ...props }: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={clsx(
+        className,
+        "mt-8 flex flex-col-reverse items-center justify-end gap-3 *:w-full sm:flex-row sm:*:w-auto"
+      )}
+    />
+  );
+}

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,5 +1,6 @@
 export * from "./badge";
 export * from "./button";
+export * from "./dialog";
 export * from "./heading";
 export * from "./link";
 export * from "./text";

--- a/src/components/project-display.client.tsx
+++ b/src/components/project-display.client.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Image, { type StaticImageData } from "next/image";
+import { useState } from "react";
+
+import {
+  Badge,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+  Heading,
+  Subheading,
+  Text,
+} from "@/components/base";
+import { BilingualString } from "@/types";
+
+export type ProjectDisplayPeriod = {
+  start: { year: number; month: number };
+  end: { year: number; month: number };
+};
+
+export type ProjectDisplayClientProps = {
+  image: StaticImageData;
+  title: BilingualString;
+  brief: BilingualString;
+  techStack: string[];
+  period: ProjectDisplayPeriod;
+};
+
+export function ProjectDisplayClient({
+  image,
+  title,
+  brief,
+  techStack,
+  period,
+}: ProjectDisplayClientProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="mx-10 my-4 w-90 text-left transition outline-none focus-visible:ring-2 focus-visible:ring-zinc-950/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-white/60 dark:focus-visible:ring-offset-zinc-950"
+      >
+        <div className="relative aspect-square overflow-hidden rounded-[15.625%] bg-white shadow-md">
+          <Image
+            src={image}
+            fill
+            style={{ objectFit: "cover" }}
+            alt={`image of ${title.en}`}
+          />
+        </div>
+        <div className="h-10" />
+        <Text>
+          {period.start.year}. {period.start.month}. ~ {period.end.year}. {period.end.month}.
+        </Text>
+        <div className="flex items-baseline gap-2">
+          <Heading>{title.ko}</Heading>
+          <Subheading>{title.en}</Subheading>
+        </div>
+        <div className="h-3" />
+        <Text>{brief.ko}</Text>
+        <div className="h-5" />
+        <Text>{brief.en}</Text>
+        <div className="h-5"></div>
+        <div className="flex flex-wrap gap-1">
+          {techStack.map((tech) => (
+            <Badge key={tech}>{tech}</Badge>
+          ))}
+        </div>
+      </button>
+
+      <Dialog open={isOpen} onClose={handleClose} size="2xl">
+        <DialogTitle>{title.ko}</DialogTitle>
+        <DialogDescription>{brief.ko}</DialogDescription>
+        <DialogBody className="space-y-6">
+          <div className="space-y-2">
+            <Subheading>{title.en}</Subheading>
+            <Text>{brief.en}</Text>
+          </div>
+
+          <div className="space-y-2">
+            <Heading className="text-base font-semibold">프로젝트 기간</Heading>
+            <Text>
+              {period.start.year}. {period.start.month}. ~ {period.end.year}. {period.end.month}.
+            </Text>
+          </div>
+
+          <div className="space-y-3">
+            <Heading className="text-base font-semibold">기술 스택</Heading>
+            <div className="flex flex-wrap gap-2">
+              {techStack.map((tech) => (
+                <Badge key={`modal-${tech}`}>{tech}</Badge>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Heading className="text-base font-semibold">프로젝트 소개</Heading>
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim
+              sit amet, adipiscing nec, ultricies sed, dolor.
+            </Text>
+            <Text>
+              Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi. Proin porttitor,
+              orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat.
+            </Text>
+            <Text>
+              Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue. Ut in
+              risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue.
+            </Text>
+          </div>
+        </DialogBody>
+        <DialogActions className="sm:hidden">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-lg bg-zinc-950 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-950 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200 dark:focus-visible:outline-white"
+          >
+            닫기
+          </button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/project-display.tsx
+++ b/src/components/project-display.tsx
@@ -1,16 +1,12 @@
-import Image, { type StaticImageData } from "next/image";
 import { Temporal } from "temporal-polyfill";
 
-import { Heading, Subheading, Text } from "@/components/base";
-import { BilingualString } from "@/types";
+import {
+  ProjectDisplayClient,
+  type ProjectDisplayClientProps,
+  type ProjectDisplayPeriod,
+} from "./project-display.client";
 
-import { Badge } from "./base/badge";
-
-type ProjectDisplayProps = {
-  image: StaticImageData;
-  title: BilingualString;
-  brief: BilingualString;
-  techStack: string[];
+type ProjectDisplayProps = Omit<ProjectDisplayClientProps, "period"> & {
   startedAt: Temporal.PlainDate;
   endedAt: Temporal.PlainDate;
 };
@@ -24,33 +20,19 @@ export function ProjectDisplay({
   endedAt,
 }: ProjectDisplayProps) {
   return (
-    <div className="mx-10 my-4 w-90">
-      <div className="relative aspect-square overflow-hidden rounded-[15.625%] bg-white shadow-md">
-        <Image
-          src={image}
-          fill
-          style={{ objectFit: "cover" }}
-          alt={`image of ${title.en}`}
-        />
-      </div>
-      <div className="h-10" />
-      <Text>
-        {startedAt.year}. {startedAt.month}. ~ {endedAt.year}. {endedAt.month}.
-      </Text>
-      <div className="flex items-baseline gap-2">
-        <Heading>{title.ko}</Heading>
-        <Subheading>{title.en}</Subheading>
-      </div>
-      <div className="h-3" />
-      <Text>{brief.ko}</Text>
-      <div className="h-5" />
-      <Text>{brief.en}</Text>
-      <div className="h-5"></div>
-      <div className="flex flex-wrap gap-1">
-        {techStack.map((tech) => (
-          <Badge key={tech}>{tech}</Badge>
-        ))}
-      </div>
-    </div>
+    <ProjectDisplayClient
+      image={image}
+      title={title}
+      brief={brief}
+      techStack={techStack}
+      period={mapPeriod(startedAt, endedAt)}
+    />
   );
+}
+
+function mapPeriod(startedAt: Temporal.PlainDate, endedAt: Temporal.PlainDate): ProjectDisplayPeriod {
+  return {
+    start: { year: startedAt.year, month: startedAt.month },
+    end: { year: endedAt.year, month: endedAt.month },
+  };
 }


### PR DESCRIPTION
## Summary
- hide the dialog action bar on screens `sm` and up so the close button only appears on mobile layouts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f4d5f983b0832eba3579e956053f27