### PR TITLE
Add ambient walker silhouette animation to hero

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -2,11 +2,13 @@
 
 import { Heading, Text } from "./base";
 import { ArrowRightIcon } from "./icons";
+import { ShadowWalker } from "./shadow-walker";
+import { Walker } from "./walker";
 
 export function HeroSection() {
   return (
-    <div className="relative h-screen w-300 bg-stone-200 p-10">
-      <div className="flex gap-20">
+    <div className="relative h-screen w-300 overflow-hidden bg-stone-200 p-10">
+      <div className="relative z-10 flex gap-20">
         <Heading className="text-[144px]/[144px]!">
           seheon<span className="text-[180px]">.</span>yu
         </Heading>
@@ -14,9 +16,18 @@ export function HeroSection() {
           Seheon is frontend engineer, this is exhibition of his works
         </Text>
       </div>
-      <div className="absolute bottom-10 left-10 flex flex-col items-center">
+      <div className="absolute bottom-10 left-10 z-10 flex flex-col items-center">
         <Heading>Exhibition This way</Heading>
         <ArrowRightIcon className="size-40" />
+      </div>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <ShadowWalker className="bottom-16" />
+        <Walker
+          className="absolute bottom-24 left-[-12vw] opacity-20"
+          size={1.1}
+          speed={0.8}
+          move
+        />
       </div>
     </div>
   );

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -2,3 +2,5 @@ export * from "./epilogue-section";
 export * from "./hero-section";
 export * from "./horizontal-scene";
 export * from "./project-display";
+export * from "./shadow-walker";
+export * from "./walker";

--- a/src/components/shadow-walker.tsx
+++ b/src/components/shadow-walker.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { motion } from "motion/react";
+
+import { twcn } from "@/utilities";
+
+interface ShadowWalkerProps {
+  className?: string;
+  duration?: number;
+  delay?: number;
+}
+
+export function ShadowWalker({
+  className,
+  duration = 20,
+  delay = 0,
+}: ShadowWalkerProps) {
+  return (
+    <motion.div
+      className={twcn(
+        "pointer-events-none absolute bottom-20 left-[-10vw] h-12 w-28 rounded-full bg-stone-900/25 blur-3xl",
+        className,
+      )}
+      animate={{
+        x: ["-10vw", "110vw"],
+        scale: [1, 1.1, 1],
+        opacity: [0.25, 0.4, 0.25],
+      }}
+      transition={{
+        duration,
+        repeat: Infinity,
+        ease: "easeInOut",
+        delay,
+      }}
+    />
+  );
+}

--- a/src/components/walker.tsx
+++ b/src/components/walker.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { motion } from "motion/react";
+
+import { twcn } from "@/utilities";
+
+interface WalkerProps {
+  className?: string;
+  size?: number;
+  speed?: number;
+  move?: boolean;
+}
+
+export function Walker({ className, size = 1, speed = 1, move = false }: WalkerProps) {
+  const travelDuration = 24 / speed;
+  const stepDuration = 1.8 / speed;
+
+  return (
+    <motion.div
+      className={twcn("pointer-events-none relative h-48 w-24", className)}
+      style={{ scale: size }}
+      animate={{
+        ...(move ? { x: ["-10vw", "110vw"] } : { x: 0 }),
+        y: [0, -6, 0],
+      }}
+      transition={{
+        x: move
+          ? {
+              duration: travelDuration,
+              repeat: Infinity,
+              ease: "linear",
+            }
+          : undefined,
+        y: {
+          duration: stepDuration,
+          repeat: Infinity,
+          repeatType: "mirror",
+          ease: "easeInOut",
+        },
+      }}
+    >
+      <motion.span
+        className="absolute left-1/2 top-0 h-10 w-10 -translate-x-1/2 rounded-full bg-stone-900/60"
+        animate={{ scaleY: [1, 0.97, 1] }}
+        transition={{
+          duration: stepDuration,
+          repeat: Infinity,
+          repeatType: "mirror",
+          ease: "easeInOut",
+        }}
+      />
+      <span className="absolute left-1/2 top-10 h-24 w-4 -translate-x-1/2 rounded-full bg-stone-900/60" />
+      <motion.span
+        className="absolute left-[34%] top-16 h-20 w-3 origin-top rounded-full bg-stone-900/60"
+        animate={{ rotate: [18, -18, 18] }}
+        transition={{
+          duration: stepDuration,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      />
+      <motion.span
+        className="absolute left-[66%] top-16 h-20 w-3 origin-top rounded-full bg-stone-900/60"
+        animate={{ rotate: [-18, 18, -18] }}
+        transition={{
+          duration: stepDuration,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      />
+      <motion.span
+        className="absolute left-[36%] top-32 h-24 w-3 origin-top rounded-full bg-stone-900/60"
+        animate={{ rotate: [-12, 12, -12] }}
+        transition={{
+          duration: stepDuration,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      />
+      <motion.span
+        className="absolute left-[64%] top-32 h-24 w-3 origin-top rounded-full bg-stone-900/60"
+        animate={{ rotate: [12, -12, 12] }}
+        transition={{
+          duration: stepDuration,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      />
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable ShadowWalker and Walker components that animate subtle silhouettes
- layer the walker and its shadow over the hero section to convey a visitor moving through the exhibition

## Testing
- pnpm lint *(fails: tailwindcss config path cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68f8a82be6c0832eb743c72aee794336