### PR TITLE
fix(ci): use pnpm and ESLint 9 in ESLint workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,39 @@
+name: ESLint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  eslint:
+    name: Run eslint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install ESLint
+        run: |
+          npm install eslint@8.10.0
+          npm install @microsoft/eslint-formatter-sarif@3.1.0
+
+      - name: Run ESLint
+        env:
+          SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
+        run: npx eslint .
+          --config eslint.config.mjs
+          --ext .js,.jsx,.ts,.tsx
+          --format @microsoft/eslint-formatter-sarif
+          --output-file eslint-results.sarif
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: eslint-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -17,19 +17,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install ESLint
-        run: |
-          npm install eslint@8.10.0
-          npm install @microsoft/eslint-formatter-sarif@3.1.0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install SARIF formatter
+        run: pnpm add -D @microsoft/eslint-formatter-sarif
 
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: npx eslint .
-          --config eslint.config.mjs
-          --ext .js,.jsx,.ts,.tsx
-          --format @microsoft/eslint-formatter-sarif
-          --output-file eslint-results.sarif
+        run: |
+          pnpm exec eslint . \
+            --format @microsoft/eslint-formatter-sarif \
+            --output-file eslint-results.sarif
         continue-on-error: true
 
       - name: Upload analysis results to GitHub


### PR DESCRIPTION
## Summary

- Replace `npm install eslint@8.10.0` with `pnpm/action-setup` + `pnpm install` to use the project's own ESLint 9 installation
- Add `actions/setup-node@v4` with pnpm cache for faster installs
- Install `@microsoft/eslint-formatter-sarif` via pnpm instead of npm
- Remove `--ext` flag (dropped in ESLint 9 flat config) and `--config` flag (auto-detected)
- Switch from `npx eslint` to `pnpm exec eslint`

## Root cause

The original workflow installed `eslint@8.10.0` via npm, but `eslint-config-next@16.1.6` requires `eslint>=9.0.0`, causing an `ERESOLVE` dependency conflict on install.

## Test plan

- [x] ESLint workflow passes on this PR
- [x] SARIF results are uploaded and visible in the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)